### PR TITLE
print help if no args given

### DIFF
--- a/cmd/root.go
+++ b/cmd/root.go
@@ -40,7 +40,9 @@ var RootCmd = &cobra.Command{
 upload your rpm packages and download from.`,
 	// Uncomment the following line if your bare application
 	// has an action associated with it:
-	Run: func(cmd *cobra.Command, args []string) {},
+	Run: func(cmd *cobra.Command, args []string) {
+		cmd.Usage()
+	},
 }
 
 // Execute adds all child commands to the root command and sets flags appropriately.


### PR DESCRIPTION
I noticed that if you just call the main binary without any commands or flags it looks like the program just dies.
Technically is not true, because the program do a normal exit as it simply has nothing to do without a command or flag.
This commit makes this a little bit easier, by print the usage informations, if no command or flag is given.