### PR TITLE
fix upload in protected mode

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -140,14 +140,12 @@ func apiPostUploadHandler(w http.ResponseWriter, r *http.Request, _ httprouter.P
 	// check if the uploaded file already exists
 	// if the repository is configured in protected mode
 	// the request will return status 403 (forbidden)
-	if _, err := os.Stat(repoPath + "/" + handler.Filename); err == nil {
-		if viper.GetBool("yum.protected") {
+	if viper.GetBool("yum.protected") {
+		if _, err := os.Stat(repoPath + "/" + handler.Filename); err == nil {
 			errText = fmt.Sprintf("%s - File already exists, forbidden to overwrite!", r.URL)
 			log.Println(errText)
 			http.Error(w, errText, http.StatusForbidden)
 			return
-		} else {
-			log.Println("File already exists, will overwrite: " + handler.Filename)
 		}
 	}
 

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -141,12 +141,12 @@ func apiPostUploadHandler(w http.ResponseWriter, r *http.Request, _ httprouter.P
 	// if the repository is configured in protected mode
 	// the request will return status 403 (forbidden)
 	if _, err := os.Stat(repoPath + "/" + handler.Filename); err == nil {
-        if viper.GetBool("yum.protected") {
+		if viper.GetBool("yum.protected") {
 			errText = fmt.Sprintf("%s - File already exists, forbidden to overwrite!", r.URL)
 			log.Println(errText)
 			http.Error(w, errText, http.StatusForbidden)
 			return
-        } else {
+		} else {
 			log.Println("File already exists, will overwrite: " + handler.Filename)
 		}
 	}

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -140,15 +140,15 @@ func apiPostUploadHandler(w http.ResponseWriter, r *http.Request, _ httprouter.P
 	// check if the uploaded file already exists
 	// if the repository is configured in protected mode
 	// the request will return status 403 (forbidden)
-	if viper.GetBool("yum.protected") {
-		if _, err := os.Stat(repoPath + "/" + handler.Filename); err == nil {
-			errText = fmt.Sprintf("%s - File already exists, forbidden to overwrite!\n", r.URL)
+	if _, err := os.Stat(repoPath + "/" + handler.Filename); err == nil {
+        if viper.GetBool("yum.protected") {
+			errText = fmt.Sprintf("%s - File already exists, forbidden to overwrite!", r.URL)
 			log.Println(errText)
-			log.Println(err)
 			http.Error(w, errText, http.StatusForbidden)
 			return
+        } else {
+			log.Println("File already exists, will overwrite: " + handler.Filename)
 		}
-		log.Println("File already exists, will overwrite: " + handler.Filename)
 	}
 
 	// create file handler to write uploaded file to


### PR DESCRIPTION
this fix a few bugs in the `apiPostUploadHandler` while using the protected mode.

1. the error message `File already exists, will overwrite ...` was printed when the files doesn't exists
2. the error message `File already exists, will overwrite ...` will now be printed even if protected mode is disabled
3. remove redundant line break in errText

this is rebased towards pull request #9 