### PR TITLE
Rewrite file delivery

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -55,6 +55,7 @@ var serveCmd = &cobra.Command{
 
 		router := httprouter.New()
 		router.NotFound = http.FileServer(http.Dir(repoPath))
+		router.GET("/help", helpHandler)
 		router.POST("/api/upload", apiPostUploadHandler)
 		//router.PUT("/api/upload/:filename", apiUploadPut)
 		router.DELETE("/api/delete/:filename", apiDeleteHandler)

--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -54,32 +54,13 @@ var serveCmd = &cobra.Command{
 		repoPath := viper.GetString("yum.repopath")
 
 		router := httprouter.New()
-		router.Handler("GET", "/", http.FileServer(http.Dir(repoPath)))
-		router.GET("/:filename", sendFileHandler)
+		router.NotFound = http.FileServer(http.Dir(repoPath))
 		router.POST("/api/upload", apiPostUploadHandler)
 		//router.PUT("/api/upload/:filename", apiUploadPut)
 		router.DELETE("/api/delete/:filename", apiDeleteHandler)
 
 		log.Fatal(http.ListenAndServe(":"+port, router))
 	},
-}
-
-func sendFileHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
-	repoPath := viper.GetString("yum.repopath")
-	filename := ps.ByName("filename")
-	if r.URL.Path == "/help" {
-		helpHandler(w, r, ps)
-	} else if r.URL.Path == "/repodata" {
-		http.StripPrefix("/repodata", http.FileServer(http.Dir(repoPath+filename))).ServeHTTP(w, r)
-	} else {
-		if _, err := os.Stat(repoPath + "/" + filename); err == nil {
-			http.ServeFile(w, r, repoPath+"/"+filename)
-		} else if _, err := os.Stat(repoPath + "/repodata/" + filename); err == nil {
-			http.ServeFile(w, r, repoPath+"/repodata/"+filename)
-		} else {
-			http.Error(w, "404 page not found!", http.StatusNotFound)
-		}
-	}
 }
 
 func updateRepo() bool {


### PR DESCRIPTION
I hope I fixed the problems with the file delivery.

Instead of having a handler function for deliver the files, that's now done by the NotFound function from the httprouter library.

I tested that change and as far as I see we archive what we want with 20 lines less code.

This also keep the router free of variables, which might help us later when implementing new functions.