### PR TITLE
implement golint suggestions

### DIFF
--- a/cmd/serve.go
+++ b/cmd/serve.go
@@ -117,9 +117,8 @@ func checkAuthentication(r *http.Request) bool {
 	// check user and password
 	if string(authBytes) == viper.GetString("yum.auth.user")+":"+viper.GetString("yum.auth.password") {
 		return true
-	} else {
-		return false
 	}
+	return false
 }
 
 func apiDeleteHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Params) {
@@ -138,14 +137,13 @@ func apiDeleteHandler(w http.ResponseWriter, r *http.Request, ps httprouter.Para
 			log.Printf(errText)
 			http.Error(w, errText, http.StatusInternalServerError)
 			return
-		} else {
-			// file deleted
-			logText := fmt.Sprintf("%s - File deleted!\n", r.URL.Path)
-			log.Printf(logText)
-			// update repository
-			if !updateRepo() {
-				http.Error(w, "Could not update repository", http.StatusInternalServerError)
-			}
+		}
+		// file deleted
+		logText := fmt.Sprintf("%s - File deleted!\n", r.URL.Path)
+		log.Printf(logText)
+		// update repository
+		if !updateRepo() {
+			http.Error(w, "Could not update repository", http.StatusInternalServerError)
 		}
 	} else {
 		// file does not exists


### PR DESCRIPTION
`golint` currently complains about two else blocks after a return:
```
14:51:24 ~/go-path/src/github.com/Comradin/yummy [master] $ golint cmd/
cmd/serve.go:120:9: if block ends with a return statement, so drop this else and outdent its block
cmd/serve.go:141:10: if block ends with a return statement, so drop this else and outdent its block (move short variable declaration to its own line if necessary)
```

The first one I had written myself. The second one is from @Comradin.
I removed the else block as `golint` suggested.

@Comradin, are you ok with this?